### PR TITLE
Simplify check for has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Yes, the irony is not lost on me. :)
 
+## 1.2.1
+
+* Simplify code for `has`
+
 ## 1.2.0
 
 * Add [`getOr`](README.md#getor) function

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,9 @@ export const getOr = curry(
  * @param {Array<*>|Object} object the object to get the value from
  * @returns {boolean} does the path exist
  */
-export const has = curry((path, object) => (isEmptyKey(path) ? !!object : hasNestedProperty(path, object)));
+/* eslint-disable eqeqeq */
+export const has = curry((path, object) => (isEmptyKey(path) ? object != null : hasNestedProperty(path, object)));
+/* eslint-enable */
 
 /**
  * @function merge

--- a/src/utils.js
+++ b/src/utils.js
@@ -272,13 +272,7 @@ export const getDeepClone = (path, object, onMatch) => {
  * @param {*} object the object to get values from
  * @returns {boolean} does the nested path exist
  */
-export const hasNestedProperty = (path, object) => {
-  const parsedPath = getParsedPath(path);
-
-  return parsedPath.length === 1
-    ? object ? object[parsedPath[0]] !== void 0 : false
-    : onMatchAtPath(parsedPath, object, (ref, key) => !!ref && ref[key] !== void 0, false, false);
-};
+export const hasNestedProperty = (path, object) => getNestedProperty(path, object) !== void 0;
 
 /**
  * @function isEmptyKey

--- a/test/index.js
+++ b/test/index.js
@@ -764,12 +764,7 @@ test('if set will set the value on the top-level array', (t) => {
   const result = index.set(path, value, object);
 
   t.not(result, object);
-  t.deepEqual(
-    result,
-    object.map((objectValue, index) => {
-      return index === path ? value : objectValue;
-    })
-  );
+  t.deepEqual(result, object.map((objectValue, index) => (index === path ? value : objectValue)));
 });
 
 test('if set will set the value on the deeply-nested object', (t) => {


### PR DESCRIPTION
* Make empty key check if not null or undefined instead of just truthy
* Have `has` leverage `getNestedProperty` and just check if result is undefined