### PR TITLE
add not and notWith methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Yes, the irony is not lost on me. :)
 
+## 2.1.0
+
+- Add [not](README.md#not) and [notWith](README.md#notwith) methods
+- Ensure that objects with custom prototypes always use the same creator
+
 ## 2.0.1
 
 - Fix [#33](https://github.com/planttheidea/unchanged/issues/33) - ensure objects created with `Object.create(null)` do not error

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Supports nested key paths via path arrays or [dotty syntax](https://github.com/p
   - [remove](#remove)
   - [has](#has)
   - [is](#is)
+  - [not](#not)
   - [add](#add)
   - [merge](#merge)
   - [assign](#assign)
@@ -26,6 +27,7 @@ Supports nested key paths via path arrays or [dotty syntax](https://github.com/p
   - [removeWith](#removewith)
   - [hasWith](#haswith)
   - [isWith](#iswith)
+  - [notWith](#notwith)
   - [addWith](#addwith)
   - [mergeWith](#mergewith)
   - [assignWith](#assignwith)
@@ -250,7 +252,7 @@ function is(
 ): boolean;
 ```
 
-Returns `true` if the value at the `path` in `object` is equal to `value` based on [SameValueZero](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality) equality.
+Returns `true` if the value at the `path` in `object` is equal to `value` based on [SameValueZero](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality) equality, `false` otherwise.
 
 ```typescript
 const object: unchanged.Unchangeable = {
@@ -263,7 +265,33 @@ const object: unchanged.Unchangeable = {
 
 console.log(is("foo[0].bar", "baz", object)); // true
 console.log(is(["foo", 0, "bar"], "baz", object)); // true
-console.log(is("foo[0].bar", "quz', object)); // false
+console.log(is("foo[0].bar", "quz", object)); // false
+```
+
+### not
+
+```typescript
+function not(
+  path: unchanged.Path,
+  value: any,
+  object: unchanged.Unchangeable
+): boolean;
+```
+
+Returns `false` if the value at the `path` in `object` is equal to `value` based on [SameValueZero](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality) equality, `true` otherwise.
+
+```typescript
+const object: unchanged.Unchangeable = {
+  foo: [
+    {
+      bar: "baz"
+    }
+  ]
+};
+
+console.log(not("foo[0].bar", "baz", object)); // false
+console.log(not(["foo", 0, "bar"], "baz", object)); // false
+console.log(not("foo[0].bar", "quz", object)); // true
 ```
 
 ### add
@@ -671,7 +699,7 @@ function isWith(
 ): boolean;
 ```
 
-Returns `true` if the return value of `fn` based on the value returned from `path` in the `object` is equal to `value` based on [SameValueZero](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality) equality.
+Returns `true` if the return value of `fn` based on the value returned from `path` in the `object` is equal to `value` based on [SameValueZero](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality) equality, `false` otherwise.
 
 ```typescript
 const object: unchanged.Unchangeable = {
@@ -688,6 +716,35 @@ const fn: unchanged.withHandler = (value: any): number =>
 console.log(isWith(fn, "foo[0].bar", object)); // true
 console.log(isWith(fn, ["foo", 0, "bar"], object)); // true
 console.log(isWith(fn, "foo[0].quz", object)); // false
+```
+
+### notWith
+
+```typescript
+function notWith(
+  fn: unchanged.withHandler,
+  path: unchanged.Path,
+  object: unchanged.Unchangeable
+): boolean;
+```
+
+Returns `false` if the return value of `fn` based on the value returned from `path` in the `object` is equal to `value` based on [SameValueZero](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality) equality, `true` otherwise.
+
+```typescript
+const object: unchanged.Unchangeable = {
+  foo: [
+    {
+      bar: "baz",
+      quz: "not baz"
+    }
+  ]
+};
+const fn: unchanged.withHandler = (value: any): number =>
+  value && value.length === 3;
+
+console.log(notWith(fn, "foo[0].bar", object)); // false
+console.log(notWith(fn, ["foo", 0, "bar"], object)); // false
+console.log(notWith(fn, "foo[0].quz", object)); // true
 ```
 
 ### addWith

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -17,6 +17,8 @@ import {
   isWith,
   merge,
   mergeWith,
+  not,
+  notWith,
   remove,
   removeWith,
   set,
@@ -2581,6 +2583,353 @@ describe('mergeWith', () => {
     const result: any = mergeWith(fn, path, object);
 
     expect(result).toBe(null);
+  });
+});
+
+describe('not', () => {
+  it('should return false with the value matching at the simple array path', () => {
+    const path: unchanged.Path = ['foo'];
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = object[path[0]];
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return true with the value not matching at the simple array path', () => {
+    const path: unchanged.Path = ['foo'];
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = 'baz';
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false with the value matching at the simple string path', () => {
+    const path: unchanged.Path = 'foo';
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = object[path];
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return true with the value not matching at the simple string path', () => {
+    const path: unchanged.Path = 'foo';
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = 'baz';
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false with the value matching at the nested array path', () => {
+    const path: unchanged.Path = ['foo', 0];
+    const object: unchanged.Unchangeable = {
+      foo: ['bar'],
+    };
+    const value: any = object[path[0]][path[1]];
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return true with the value not matching at the nested array path', () => {
+    const path: unchanged.Path = ['foo', 0];
+    const object: unchanged.Unchangeable = {
+      foo: ['bar'],
+    };
+    const value: any = 'quz';
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false with the value matching at the nested string path', () => {
+    const path: unchanged.Path = 'foo[0]';
+    const object: unchanged.Unchangeable = {
+      foo: ['bar'],
+    };
+
+    const parsedPath: unchanged.ParsedPath = parse(path);
+
+    const value: any = object[parsedPath[0]][parsedPath[1]];
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return true with the value not matching at the nested string path', () => {
+    const path: unchanged.Path = 'foo[0]';
+    const object: unchanged.Unchangeable = {
+      foo: ['bar'],
+    };
+
+    const value: any = 'quz';
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false if the path is empty and the value matches', () => {
+    const path: unchanged.Path = [];
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = object;
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true if the path is empty and the value does not match', () => {
+    const path: unchanged.Path = [];
+    const object: null = null;
+    const value: any = undefined;
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if no match at the simple array path', () => {
+    const path: unchanged.Path = ['foo'];
+    const object: unchanged.Unchangeable = {};
+    const value: any = 'bar';
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if no match at the simple string path', () => {
+    const path: unchanged.Path = 'foo';
+    const object: unchanged.Unchangeable = {};
+    const value: any = 'bar';
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if no match at the nested array path', () => {
+    const path: unchanged.Path = ['foo', 0];
+    const object: unchanged.Unchangeable = {
+      foo: [],
+    };
+    const value: any = 'baz';
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if no match at the nested string path', () => {
+    const path: unchanged.Path = 'foo[0]';
+    const object: unchanged.Unchangeable = {
+      foo: [],
+    };
+    const value: any = 'baz';
+
+    const result: boolean = not(path, value, object);
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('notWith', () => {
+  it('should return false with the value matching at the simple array path', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = ['foo'];
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = 'blah';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return true with the value not matching at the simple array path', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = ['foo'];
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = 'baz';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false with the value matching at the simple string path', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = 'foo';
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = 'blah';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return true with the value not matching at the simple string path', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = 'foo';
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = 'baz';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false with the value matching at the nested array path', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = ['foo', 0];
+    const object: unchanged.Unchangeable = {
+      foo: ['bar'],
+    };
+    const value: any = 'blah';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return true with the value not matching at the nested array path', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = ['foo', 0];
+    const object: unchanged.Unchangeable = {
+      foo: ['bar'],
+    };
+    const value: any = 'quz';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false with the value matching at the nested string path', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = 'foo[0]';
+    const object: unchanged.Unchangeable = {
+      foo: ['bar'],
+    };
+
+    const value: any = 'blah';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return true with the value not matching at the nested string path', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = 'foo[0]';
+    const object: unchanged.Unchangeable = {
+      foo: ['bar'],
+    };
+
+    const value: any = 'quz';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false if the path is empty and the value matches', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value && value.foo === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = [];
+    const object: unchanged.Unchangeable = { foo: 'bar' };
+    const value: any = 'blah';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true if the path is empty and the value does not match', () => {
+    const fn: unchanged.withHandler = (value: any): boolean =>
+      value && value.foo === 'bar' ? 'blah' : value;
+    const path: unchanged.Path = [];
+    const object: null = null;
+    const value: any = 'blah';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if no match at the simple array path', () => {
+    const fn: unchanged.withHandler = (value: any) => value === 'bar';
+    const path: unchanged.Path = ['foo'];
+    const object: unchanged.Unchangeable = {};
+    const value: any = 'bar';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if no match at the simple string path', () => {
+    const fn: unchanged.withHandler = (value: any) => value === 'bar';
+    const path: unchanged.Path = 'foo';
+    const object: unchanged.Unchangeable = {};
+    const value: any = 'bar';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if no match at the nested array path', () => {
+    const fn: unchanged.withHandler = (value: any) => value === 'bar';
+    const path: unchanged.Path = ['foo', 0];
+    const object: unchanged.Unchangeable = {
+      foo: [],
+    };
+    const value: any = 'baz';
+
+    const result: boolean = notWith(fn, path, value, object);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false if no match at the nested string path', () => {
+    const fn: unchanged.withHandler = (value: any) => value === 'bar';
+    const path: unchanged.Path = 'foo[0]';
+    const object: unchanged.Unchangeable = {
+      foo: [],
+    };
+    const value: any = 'baz';
+
+    const result: boolean = isWith(fn, path, value, object);
+
+    expect(result).toBe(false);
+  });
+
+  it('should throw if the function passed is not a function', () => {
+    const fn: null = null;
+    const path: unchanged.Path = ['foo'];
+    const object: unchanged.Unchangeable = {};
+    const value: any = 'bar';
+
+    expect(() => isWith(fn, path, value, object)).toThrowError();
   });
 });
 

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -6,6 +6,7 @@ import {
   callIfFunction,
   cloneArray,
   cloneIfPossible,
+  createWithProto,
   getCoalescedValue,
   getDeepClone,
   getFullPath,
@@ -107,6 +108,33 @@ describe('cloneIfPossible', () => {
     const result: unchanged.Unchangeable = cloneIfPossible(object);
 
     expect(result).toBe(object);
+  });
+});
+
+describe('createWithProto', () => {
+  it('should clone the object with a custom prototype', () => {
+    class Foo {
+      value: any;
+
+      constructor(value: any) {
+        this.value = value;
+      }
+    }
+
+    const object: unchanged.Unchangeable = new Foo('bar');
+
+    const result: unchanged.Unchangeable = createWithProto(object);
+
+    expect(result instanceof Foo).toBe(true);
+  });
+
+  it('should clone the pure object with a null prototype', () => {
+    const object: unchanged.Unchangeable = Object.create(null);
+
+    const result: unchanged.Unchangeable = createWithProto(object);
+
+    expect(result.__proto__).toBe(undefined);
+    expect(Object.getPrototypeOf(result)).toBe(null);
   });
 });
 

--- a/benchmark_results.csv
+++ b/benchmark_results.csv
@@ -1,57 +1,57 @@
 Test,1000 ops,5000 ops,10000 ops,50000 ops,100000 ops,500000 ops,1000000 ops,5000000 ops
 ---,---,---,---,---,---,---,---,---
-[get object property] native,0.138ms,0.099ms,0.194ms,1.015ms,0.098ms,0.304ms,0.657ms,3.096ms
-[get object property] lodash fp (array),2.222ms,6.384ms,2.526ms,9.205ms,12.409ms,95.453ms,194.018ms,565.575ms
-[get object property] lodash fp (dotty),0.763ms,3.725ms,2.840ms,7.954ms,15.933ms,83.901ms,157.768ms,799.766ms
-[get object property] ramda,0.389ms,3.746ms,2.112ms,0.710ms,1.440ms,8.463ms,15.151ms,74.420ms
-[get object property] unchanged (array),0.694ms,4.098ms,3.388ms,2.140ms,4.341ms,20.535ms,41.308ms,204.487ms
-[get object property] unchanged (dotty),0.727ms,2.282ms,1.125ms,4.263ms,3.978ms,21.908ms,44.795ms,214.152ms
+[get object property] native,0.136ms,0.099ms,0.232ms,1.105ms,0.058ms,0.287ms,0.598ms,3.110ms
+[get object property] lodash fp (array),2.338ms,6.771ms,2.556ms,9.419ms,13.250ms,101.892ms,201.083ms,595.229ms
+[get object property] lodash fp (dotty),0.759ms,3.927ms,3.094ms,8.385ms,16.534ms,81.539ms,163.860ms,834.633ms
+[get object property] ramda,0.411ms,2.202ms,1.807ms,3.190ms,1.957ms,8.043ms,15.854ms,81.725ms
+[get object property] unchanged (array),0.682ms,3.065ms,4.338ms,2.420ms,4.263ms,22.422ms,44.092ms,225.337ms
+[get object property] unchanged (dotty),1.136ms,2.265ms,1.226ms,4.246ms,4.556ms,21.699ms,43.618ms,217.883ms
 ---,---,---,---,---,---,---,---,---
-[get array index] native,0.168ms,0.336ms,1.839ms,0.503ms,1.020ms,5.301ms,11.630ms,55.452ms
-[get array index] lodash fp (array),0.665ms,3.469ms,3.739ms,7.541ms,15.163ms,74.841ms,151.961ms,754.557ms
-[get array index] lodash fp (dotty),0.318ms,1.149ms,2.785ms,8.614ms,15.006ms,75.609ms,153.904ms,763.142ms
-[get array index] ramda,0.546ms,2.033ms,2.375ms,5.943ms,5.395ms,26.245ms,52.514ms,267.940ms
-[get array index] unchanged (array),0.448ms,2.530ms,2.144ms,3.002ms,5.734ms,28.107ms,56.312ms,283.232ms
-[get array index] unchanged (dotty),0.522ms,2.524ms,3.951ms,2.881ms,5.452ms,28.696ms,56.771ms,281.766ms
+[get array index] native,0.173ms,0.384ms,1.779ms,0.514ms,0.984ms,5.692ms,11.858ms,57.590ms
+[get array index] lodash fp (array),0.737ms,3.360ms,4.978ms,9.016ms,16.926ms,84.919ms,166.233ms,841.037ms
+[get array index] lodash fp (dotty),0.345ms,1.230ms,3.035ms,9.059ms,16.474ms,82.772ms,165.386ms,835.214ms
+[get array index] ramda,0.610ms,5.085ms,3.437ms,2.671ms,5.587ms,27.724ms,55.126ms,281.125ms
+[get array index] unchanged (array),0.465ms,1.986ms,4.774ms,3.116ms,6.082ms,30.044ms,58.914ms,294.013ms
+[get array index] unchanged (dotty),0.536ms,3.004ms,2.808ms,4.780ms,6.018ms,29.552ms,57.897ms,278.844ms
 ---,---,---,---,---,---,---,---,---
-[get nested object property] native,0.177ms,0.125ms,0.728ms,0.517ms,0.058ms,0.291ms,0.600ms,2.890ms
-[get nested object property] lodash fp (array),0.231ms,0.915ms,2.508ms,9.231ms,22.643ms,76.718ms,137.211ms,695.112ms
-[get nested object property] lodash fp (dotty),1.826ms,6.134ms,5.519ms,16.964ms,34.783ms,176.541ms,344.724ms,1748.713ms
-[get nested object property] ramda,0.185ms,0.511ms,3.304ms,5.387ms,5.357ms,26.258ms,52.563ms,268.836ms
-[get nested object property] unchanged (array),0.426ms,3.305ms,3.911ms,2.337ms,5.022ms,24.701ms,50.579ms,251.299ms
-[get nested object property] unchanged (dotty),0.664ms,5.036ms,4.559ms,3.532ms,7.079ms,34.940ms,72.772ms,348.123ms
+[get nested object property] native,0.118ms,0.173ms,0.725ms,0.549ms,0.058ms,0.287ms,0.670ms,3.028ms
+[get nested object property] lodash fp (array),0.237ms,1.214ms,2.676ms,9.846ms,17.440ms,80.892ms,154.977ms,751.268ms
+[get nested object property] lodash fp (dotty),1.905ms,7.585ms,4.735ms,18.132ms,36.354ms,186.463ms,363.063ms,1827.482ms
+[get nested object property] ramda,0.218ms,0.501ms,3.407ms,5.734ms,5.655ms,28.392ms,57.059ms,283.943ms
+[get nested object property] unchanged (array),0.454ms,2.368ms,4.033ms,2.790ms,5.325ms,24.541ms,48.805ms,249.486ms
+[get nested object property] unchanged (dotty),0.669ms,4.201ms,7.754ms,4.834ms,7.782ms,39.443ms,77.530ms,384.854ms
 ---,---,---,---,---,---,---,---,---
-[get nested array index] native,0.195ms,0.363ms,1.241ms,1.432ms,1.210ms,5.164ms,10.547ms,59.440ms
-[get nested array index] lodash fp (array),0.398ms,1.430ms,4.927ms,8.810ms,18.804ms,86.672ms,172.379ms,865.479ms
-[get nested array index] lodash fp (dotty),2.078ms,9.583ms,7.259ms,28.865ms,58.039ms,291.403ms,583.478ms,2938.883ms
-[get nested array index] ramda,0.340ms,1.080ms,2.169ms,7.146ms,6.287ms,31.547ms,63.452ms,317.151ms
-[get nested array index] unchanged (array),0.531ms,3.055ms,7.313ms,3.941ms,7.004ms,37.230ms,73.732ms,352.254ms
-[get nested array index] unchanged (dotty),1.071ms,5.837ms,6.128ms,9.787ms,20.575ms,99.716ms,192.645ms,963.711ms
+[get nested array index] native,0.217ms,0.391ms,1.329ms,1.363ms,1.042ms,5.567ms,12.574ms,59.032ms
+[get nested array index] lodash fp (array),0.371ms,1.431ms,4.049ms,9.374ms,18.270ms,91.253ms,186.292ms,918.037ms
+[get nested array index] lodash fp (dotty),2.995ms,7.108ms,7.479ms,31.063ms,61.765ms,308.800ms,615.352ms,3066.067ms
+[get nested array index] ramda,0.269ms,0.823ms,3.674ms,7.082ms,7.141ms,31.915ms,65.303ms,317.377ms
+[get nested array index] unchanged (array),0.556ms,2.395ms,5.208ms,4.212ms,6.503ms,32.680ms,67.452ms,336.764ms
+[get nested array index] unchanged (dotty),0.908ms,6.151ms,5.400ms,10.374ms,20.147ms,102.787ms,204.640ms,1017.968ms
 ---,---,---,---,---,---,---,---,---
-[set object property] native,0.237ms,0.641ms,1.782ms,3.946ms,6.376ms,31.737ms,59.796ms,286.608ms
-[set object property] lodash fp (array),10.054ms,19.092ms,8.648ms,34.153ms,68.316ms,346.581ms,686.756ms,3422.712ms
-[set object property] lodash fp (dotty),2.594ms,8.802ms,9.005ms,40.352ms,80.644ms,406.577ms,811.770ms,4048.518ms
-[set object property] ramda,0.517ms,4.035ms,1.247ms,3.122ms,6.123ms,30.204ms,61.129ms,308.764ms
-[set object property] unchanged (array),0.718ms,3.880ms,5.025ms,5.431ms,10.863ms,53.893ms,107.052ms,544.295ms
-[set object property] unchanged (dotty),0.839ms,6.174ms,3.907ms,7.536ms,15.414ms,75.414ms,156.433ms,762.264ms
+[set object property] native,0.331ms,1.003ms,1.852ms,3.830ms,6.452ms,35.618ms,61.027ms,296.214ms
+[set object property] lodash fp (array),7.449ms,18.794ms,8.978ms,35.838ms,71.377ms,363.448ms,716.788ms,3615.361ms
+[set object property] lodash fp (dotty),2.529ms,9.106ms,9.466ms,43.308ms,89.687ms,434.002ms,853.981ms,4326.000ms
+[set object property] ramda,0.494ms,3.320ms,1.511ms,3.216ms,6.277ms,30.859ms,62.791ms,314.186ms
+[set object property] unchanged (array),0.882ms,3.818ms,4.628ms,5.813ms,11.194ms,56.441ms,112.012ms,562.317ms
+[set object property] unchanged (dotty),0.609ms,5.097ms,3.545ms,7.563ms,14.642ms,75.990ms,149.781ms,749.184ms
 ---,---,---,---,---,---,---,---,---
-[set array index] native,0.393ms,1.200ms,3.303ms,7.035ms,14.437ms,70.575ms,134.214ms,653.764ms
-[set array index] lodash fp (array),2.552ms,18.888ms,10.489ms,44.345ms,88.839ms,447.208ms,899.255ms,4598.493ms
-[set array index] lodash fp (dotty),2.753ms,13.452ms,10.803ms,48.132ms,98.886ms,486.316ms,974.213ms,4863.323ms
-[set array index] ramda,1.419ms,7.291ms,8.731ms,38.894ms,77.183ms,389.679ms,782.479ms,3899.422ms
-[set array index] unchanged (array),1.483ms,8.289ms,5.256ms,14.457ms,29.536ms,137.278ms,275.799ms,1385.062ms
-[set array index] unchanged (dotty),0.501ms,4.286ms,4.636ms,13.794ms,27.573ms,139.254ms,278.754ms,1403.869ms
+[set array index] native,0.372ms,1.476ms,3.400ms,7.108ms,14.190ms,73.660ms,135.972ms,691.988ms
+[set array index] lodash fp (array),2.650ms,15.586ms,11.053ms,46.341ms,93.871ms,464.986ms,930.892ms,4679.029ms
+[set array index] lodash fp (dotty),2.258ms,13.457ms,11.064ms,49.223ms,98.483ms,499.770ms,994.734ms,5015.549ms
+[set array index] ramda,1.294ms,7.536ms,9.033ms,38.915ms,77.623ms,395.582ms,798.564ms,3932.365ms
+[set array index] unchanged (array),2.113ms,6.559ms,5.156ms,14.352ms,28.239ms,142.284ms,284.923ms,1421.981ms
+[set array index] unchanged (dotty),0.481ms,4.224ms,4.588ms,13.795ms,27.658ms,138.392ms,277.323ms,1389.386ms
 ---,---,---,---,---,---,---,---,---
-[set nested object property] native,0.420ms,1.164ms,4.524ms,6.045ms,12.772ms,61.088ms,115.786ms,581.754ms
-[set nested object property] lodash fp (array),12.289ms,16.878ms,18.022ms,86.544ms,167.376ms,847.402ms,1693.723ms,8483.003ms
-[set nested object property] lodash fp (dotty),2.438ms,15.991ms,20.183ms,94.682ms,190.674ms,944.250ms,1887.299ms,9406.902ms
-[set nested object property] ramda,1.477ms,5.295ms,7.510ms,32.401ms,58.188ms,293.330ms,584.549ms,2926.187ms
-[set nested object property] unchanged (array),2.677ms,4.461ms,5.044ms,10.838ms,20.997ms,107.293ms,211.742ms,1056.181ms
-[set nested object property] unchanged (dotty),0.666ms,3.119ms,5.134ms,12.715ms,25.832ms,127.086ms,257.454ms,1280.485ms
+[set nested object property] native,0.440ms,1.139ms,3.562ms,6.556ms,23.877ms,64.570ms,113.066ms,566.651ms
+[set nested object property] lodash fp (array),9.859ms,16.325ms,18.012ms,82.009ms,156.716ms,796.640ms,1579.432ms,7881.424ms
+[set nested object property] lodash fp (dotty),2.430ms,12.926ms,22.232ms,97.228ms,192.944ms,971.451ms,1943.218ms,11356.362ms
+[set nested object property] ramda,1.937ms,7.482ms,8.796ms,38.644ms,76.118ms,393.023ms,768.595ms,3773.399ms
+[set nested object property] unchanged (array),1.165ms,5.359ms,5.304ms,15.403ms,23.183ms,110.429ms,218.883ms,1203.575ms
+[set nested object property] unchanged (dotty),0.584ms,2.624ms,8.669ms,19.362ms,33.358ms,160.903ms,322.447ms,1582.931ms
 ---,---,---,---,---,---,---,---,---
-[set nested array index] native,0.543ms,3.975ms,5.077ms,14.565ms,30.363ms,137.218ms,271.223ms,1350.483ms
-[set nested array index] lodash fp (array),4.566ms,16.831ms,16.508ms,72.553ms,146.428ms,725.282ms,1454.054ms,7268.689ms
-[set nested array index] lodash fp (dotty),2.688ms,14.192ms,18.616ms,84.659ms,169.493ms,839.906ms,1678.044ms,8401.912ms
-[set nested array index] ramda,2.098ms,9.228ms,14.369ms,58.027ms,113.253ms,574.311ms,1147.671ms,5739.981ms
-[set nested array index] unchanged (array),1.434ms,13.491ms,10.443ms,39.798ms,79.282ms,399.261ms,799.325ms,3995.922ms
-[set nested array index] unchanged (dotty),1.871ms,10.817ms,11.901ms,51.390ms,98.743ms,494.316ms,990.243ms,4959.485ms
+[set nested array index] native,0.615ms,4.031ms,4.741ms,14.904ms,32.658ms,155.984ms,338.253ms,1615.511ms
+[set nested array index] lodash fp (array),4.557ms,26.419ms,20.432ms,77.262ms,148.498ms,786.219ms,1561.574ms,7780.584ms
+[set nested array index] lodash fp (dotty),3.295ms,15.402ms,19.143ms,92.085ms,202.078ms,1059.790ms,1954.621ms,9558.560ms
+[set nested array index] ramda,2.766ms,11.616ms,16.234ms,71.476ms,142.635ms,678.140ms,1159.120ms,5812.016ms
+[set nested array index] unchanged (array),1.493ms,13.068ms,10.963ms,41.755ms,83.378ms,414.816ms,834.468ms,4186.297ms
+[set nested array index] unchanged (dotty),1.432ms,10.531ms,15.195ms,51.707ms,99.045ms,492.594ms,991.509ms,5030.826ms

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,6 +119,20 @@ declare module 'unchanged' {
     ...extraArgs: any[]
   ): unchanged.Unchangeable;
 
+  export function not(
+    path: unchanged.Path,
+    value: any,
+    object: unchanged.Unchangeable,
+  ): boolean;
+
+  export function notWith(
+    fn: unchanged.withHandler,
+    path: unchanged.Path,
+    value: any,
+    object: unchanged.Unchangeable,
+    ...extraArgs: any[]
+  ): boolean;
+
   export function remove(
     path: unchanged.Path,
     object: unchanged.Unchangeable,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -309,6 +309,23 @@ export const createMerge: Function = (
 };
 
 /**
+ * @function createNot
+ *
+ * @description
+ * create handlers for not / notWith
+ *
+ * @param isWithHandler not the method using a with handler
+ * @returns not / notWithHandler
+ */
+export const createNot: Function = (isWithHandler: boolean): Function => {
+  const is: Function = createIs(isWithHandler);
+
+  return function () {
+    return !is.apply(this, arguments);
+  };
+};
+
+/**
  * @function createRemove
  *
  * @description

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   createHas,
   createIs,
   createMerge,
+  createNot,
   createRemove,
   createSet,
 } from './handlers';
@@ -47,6 +48,10 @@ export const isWith = curry(createIs(true), 4);
 export const merge = curry(createMerge(false, true), 3);
 
 export const mergeWith = curry(createMerge(true, true), 3);
+
+export const not = curry(createNot(false), 3);
+
+export const notWith = curry(createNot(true), 4);
 
 export const remove = curry(createRemove(false), 2);
 

--- a/src/unchanged.d.ts
+++ b/src/unchanged.d.ts
@@ -119,6 +119,20 @@ declare module 'unchanged' {
     ...extraArgs: any[]
   ): unchanged.Unchangeable;
 
+  export function not(
+    path: unchanged.Path,
+    value: any,
+    object: unchanged.Unchangeable,
+  ): boolean;
+
+  export function notWith(
+    fn: unchanged.withHandler,
+    path: unchanged.Path,
+    value: any,
+    object: unchanged.Unchangeable,
+    ...extraArgs: any[]
+  ): boolean;
+
   export function remove(
     path: unchanged.Path,
     object: unchanged.Unchangeable,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,6 +138,19 @@ const assign: Function =
   typeof O.assign === 'function' ? O.assign : assignFallback;
 
 /**
+ * @function createWithProto
+ *
+ * @description
+ * create a new object with the prototype of the object passed
+ *
+ * @param object object whose prototype will be the new object's prototype
+ * @returns object with the prototype of the one passed
+ */
+export const createWithProto: Function = (
+  object: unchanged.Unchangeable,
+): unchanged.Unchangeable => create(object.__proto__ || getPrototypeOf(object));
+
+/**
  * @function isCloneable
  *
  * @description
@@ -183,8 +196,7 @@ export const isEmptyPath: Function = (path: any): boolean =>
  */
 export const isGlobalConstructor: Function = (fn: any): boolean =>
   typeof fn === 'function' &&
-  // @ts-ignore
-  global[fn.name || toStringFunction.call(fn).split(FUNCTION_NAME)[1]] === fn;
+  !!~toStringFunction.call(fn).indexOf('[native code]');
 
 /**
  * @function callIfFunction
@@ -251,7 +263,7 @@ export const getShallowClone = (
 
   return isGlobalConstructor(object.constructor)
     ? {}
-    : assign(create(object.__proto__ || getPrototypeOf(object)), object);
+    : assign(createWithProto(object), object);
 };
 
 /**
@@ -420,7 +432,7 @@ export const getMergedObject: Function = (
   const targetClone: unchanged.Unchangeable =
     target.constructor === O || isGlobalConstructor(target.constructor)
       ? {}
-      : create(target.__proto__);
+      : createWithProto(target);
 
   return reduce(
     getOwnProperties(source),

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,9 +115,9 @@
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/jest@^23.3.12":
-  version "23.3.12"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.12.tgz#7e0ced251fa94c3bc2d1023d4b84b2992fa06376"
-  integrity sha512-/kQvbVzdEpOq4tEWT79yAHSM4nH4xMlhJv2GrLVQt4Qmo8yYsPdioBM1QpN/2GX1wkfMnyXvdoftvLUr0LBj7Q==
+  version "23.3.13"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.13.tgz#c81484b6f4ca007bb09887ed15ecb3286d58f928"
+  integrity sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA==
 
 "@types/node@*", "@types/node@^10.12.18":
   version "10.12.18"
@@ -130,14 +130,14 @@
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
 "@types/ramda@^0.25.45":
-  version "0.25.46"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.46.tgz#8399a35eb117f4a821deb9c4cfecc9b276fb7daf"
-  integrity sha512-UiyHmzWu0KftAWZXfiUvwToVTHGhaG2fnWVckGwaic4By6YyGqtOpq7m8R3HLrpEsYH0AnRQjtXhdL8igmCuDw==
+  version "0.25.47"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.47.tgz#904f2ee46149af42902fe7dc01867e32798e8b37"
+  integrity sha512-+ffSU83+PR4/cZtNTkUcFkg70sK4GePle7p5h05bQ37ycPumOx/TBpU52bt36GKDlds6tCqXheqPvgC52MMLug==
 
 "@types/react@^16.7.18":
-  version "16.7.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.18.tgz#f4ce0d539a893dd61e36cd11ae3a5e54f5a48337"
-  integrity sha512-Tx4uu3ppK53/iHk6VpamMP3f3ahfDLEVt3ZQc8TFm30a1H3v9lMsCntBREswZIW/SKrvJjkb3Hq8UwO6GREBng==
+  version "16.7.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
+  integrity sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -313,12 +313,10 @@ accepts@~1.3.4, accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
-acorn-dynamic-import@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
-  integrity sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==
-  dependencies:
-    acorn "^5.0.0"
+acorn-dynamic-import@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
+  integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
 
 acorn-globals@^4.1.0:
   version "4.3.0"
@@ -338,7 +336,7 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
   integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
 
-acorn@^5.0.0, acorn@^5.5.3, acorn@^5.6.2:
+acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
@@ -359,9 +357,9 @@ ajv-keywords@^3.1.0:
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
 ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.6.1:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
-  integrity sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.7.0.tgz#e3ce7bb372d6577bb1839f1dfdfcbf5ad2948d96"
+  integrity sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1512,9 +1510,9 @@ cssstyle@^1.0.0:
     cssom "0.3.x"
 
 csstype@^2.2.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.0.tgz#6cf7b2fa7fc32aab3d746802c244d4eda71371a2"
-  integrity sha512-by8hi8BlLbowQq0qtkx54d9aN73R9oUW20HISpka5kmgsR9F7nnxgfsemuR2sdCKZh+CDNf5egW9UZMm4mgJRg==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.1.tgz#4cfbf637a577497036ebcd7e32647ef19a0b8076"
+  integrity sha512-wv7IRqCGsL7WGKB8gPvrl+++HlFM9kxAM6jL1EXNPNTshEJYilMkbfS2SnuHha77uosp/YVK0wAp2jmlBzn1tg==
 
 curriable@^1.2.4:
   version "1.2.4"
@@ -1986,9 +1984,9 @@ eslint-visitor-keys@^1.0.0:
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
 eslint@^5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.12.0.tgz#fab3b908f60c52671fb14e996a450b96c743c859"
-  integrity sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.12.1.tgz#5ca9931fb9029d04e7be92b03ce3b58edfac7e3b"
+  integrity sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.5.3"
@@ -2091,10 +2089,10 @@ eventemitter3@^3.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
-events@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
 
 eventsource@^1.0.7:
   version "1.0.7"
@@ -2564,9 +2562,9 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.2, fsevents@^1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
-  integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
+  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
@@ -3886,9 +3884,9 @@ jest-worker@^23.2.0:
     merge-stream "^1.0.1"
 
 jest-worker@^24.0.0-alpha.9:
-  version "24.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.0.0-alpha.10.tgz#046702c758ae3214cd279e602055a26b066122be"
-  integrity sha512-oU+4FRtzBkHzU1aQSYuUJMaP3QNN1nsDH/nQ2EgKduVPOKz5rdOrTfnyPdr/r/q70iAJRmrnaSvlfnEWgWXoiQ==
+  version "24.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.0.0-alpha.12.tgz#b7ca1fb774b4eddc342768b7a63d89be5e6a762f"
+  integrity sha512-BzGiUwc2LPyrvOuCMqdiLqWU78C+lHbHI/hcJgWonTda0RS7aCcrgSJx5t9+56U9rzMMxDC75S9khJ0oi3fYQA==
   dependencies:
     merge-stream "^1.0.1"
     supports-color "^5.5.0"
@@ -4130,9 +4128,9 @@ load-json-file@^4.0.0:
     strip-bom "^3.0.0"
 
 loader-runner@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.1.tgz#026f12fe7c3115992896ac02ba022ba92971b979"
-  integrity sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
+  integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
 loader-utils@^0.2.16:
   version "0.2.17"
@@ -4260,9 +4258,9 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 math-random@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
-  integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
+  integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
 
 md5-hex@^2.0.0:
   version "2.0.0"
@@ -4603,9 +4601,9 @@ node-int64@^0.4.0:
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
 node-libs-browser@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
-  integrity sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.0.tgz#c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77"
+  integrity sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==
   dependencies:
     assert "^1.1.1"
     browserify-zlib "^0.2.0"
@@ -4614,7 +4612,7 @@ node-libs-browser@^2.0.0:
     constants-browserify "^1.0.0"
     crypto-browserify "^3.11.0"
     domain-browser "^1.1.1"
-    events "^1.0.0"
+    events "^3.0.0"
     https-browserify "^1.0.0"
     os-browserify "^0.3.0"
     path-browserify "0.0.0"
@@ -4628,7 +4626,7 @@ node-libs-browser@^2.0.0:
     timers-browserify "^2.0.4"
     tty-browserify "0.0.0"
     url "^0.11.0"
-    util "^0.10.3"
+    util "^0.11.0"
     vm-browserify "0.0.4"
 
 node-notifier@^5.2.1:
@@ -4989,9 +4987,9 @@ package-hash@^2.0.0:
     release-zalgo "^1.0.0"
 
 pako@~1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
-  integrity sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
+  integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
 
 parallel-transform@^1.1.0:
   version "1.1.0"
@@ -5017,15 +5015,16 @@ parent-module@^1.0.0:
     callsites "^3.0.0"
 
 parse-asn1@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.1.tgz#f6bf293818332bd0dab54efb16087724745e6ca8"
-  integrity sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.3.tgz#1600c6cc0727365d68b97f3aa78939e735a75204"
+  integrity sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
     create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
+    safe-buffer "^5.1.1"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -5540,9 +5539,9 @@ realpath-native@^1.0.0:
     util.promisify "^1.0.0"
 
 reflect-metadata@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.12.tgz#311bf0c6b63cd782f228a81abe146a2bfa9c56f2"
-  integrity sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A==
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -5787,9 +5786,9 @@ rollup-pluginutils@2.3.3:
     micromatch "^2.3.11"
 
 rollup@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.1.0.tgz#461a7534b55be48aa4a6e6810a1543a5769e75d1"
-  integrity sha512-NK03gkkOz0CchHBMGomcNqa6U3jLNzHuWK9SI0+1FV475JA6cQxVtjlDcQoKKDNIQ3IwYumIlgoKYDEWUyFBwQ==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.1.1.tgz#adda83b685e341adedd065877a1ff09b7a57dfca"
+  integrity sha512-0bNXof9J3Qy0PeAoB6Nu0SBl6yOEZ4qnFVcicZULYBe4+6/s7ApVzF7SeLVBgLxtlgAoBSSGmR6P0ecnCoXrYA==
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"
@@ -6106,9 +6105,9 @@ source-map-support@^0.4.15:
     source-map "^0.5.6"
 
 source-map-support@^0.5.6, source-map-support@~0.5.6:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
-  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
+  integrity sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -6395,9 +6394,9 @@ symbol-tree@^3.2.2:
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
 table@^5.0.2:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.1.1.tgz#92030192f1b7b51b6eeab23ed416862e47b70837"
-  integrity sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.2.1.tgz#e78463702b1be9f7131c39860bcfb1b81114c2a1"
+  integrity sha512-qmhNs2GEHNqY5fd2Mo+8N1r2sw/rvTAAvBZTaTx+Y7PHLypqyrxr1MdIu0pLw6Xvl/Gi4ONu/sdceP8vvUjkyA==
   dependencies:
     ajv "^6.6.1"
     lodash "^4.17.11"
@@ -6677,9 +6676,9 @@ tslint-microsoft-contrib@~5.2.1:
     tsutils "^2.27.2 <2.29.0"
 
 tslint@^5.11.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.0.tgz#47f2dba291ed3d580752d109866fb640768fca36"
-  integrity sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.1.tgz#8cec9d454cf8a1de9b0a26d7bdbad6de362e52c1"
+  integrity sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -6753,9 +6752,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^3.1.3:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
 uglify-js@3.4.x, uglify-js@^3.1.4:
   version "3.4.9"
@@ -6870,10 +6869,10 @@ util@0.10.3:
   dependencies:
     inherits "2.0.1"
 
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+util@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
 
@@ -7051,16 +7050,16 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-map "~0.6.1"
 
 webpack@^4.16.5:
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.28.1.tgz#d0e2856e75d1224b170bf16c30b6ca9b75f0d958"
-  integrity sha512-qAS7BFyS5iuOZzGJxyDXmEI289h7tVNtJ5XMxf6Tz55J2riOyH42uaEsWF0F32TRaI+54SmI6qRgHM3GzsZ+sQ==
+  version "4.29.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.29.0.tgz#f2cfef83f7ae404ba889ff5d43efd285ca26e750"
+  integrity sha512-pxdGG0keDBtamE1mNvT5zyBdx+7wkh6mh7uzMOo/uRQ/fhsdj5FXkh/j5mapzs060forql1oXqXN9HJGju+y7w==
   dependencies:
     "@webassemblyjs/ast" "1.7.11"
     "@webassemblyjs/helper-module-context" "1.7.11"
     "@webassemblyjs/wasm-edit" "1.7.11"
     "@webassemblyjs/wasm-parser" "1.7.11"
-    acorn "^5.6.2"
-    acorn-dynamic-import "^3.0.0"
+    acorn "^6.0.5"
+    acorn-dynamic-import "^4.0.0"
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
     chrome-trace-event "^1.0.0"


### PR DESCRIPTION
- add `not` and `notWith` methods to API
- ensure creation of custom objects (non-`Object` prototype) are created with the same handler
- allow isGlobalConstructor to work cross-realm